### PR TITLE
Add CH*PNR operator ID

### DIFF
--- a/List of Charging Point Operators.md
+++ b/List of Charging Point Operators.md
@@ -18,7 +18,8 @@
 | CH*MOBIMOEMOBILITY | Mobimo emobility | 14.06.2021 |
 | CH*PACEMOBILITY | PAC e-moblity | 14.06.2021 |
 | CH*PARKCHARGE | PARK & CHARGE | 14.06.2021 |
-| CH*REP | Plug'n Roll | 25.09.2019 |
+| CH*PNR | PLUG'N ROLL | 12.09.2023 |
+| CH*REP | PLUG'N ROLL | 25.09.2019 |
 | CH*SCH | Saascharge | 22.05.2023 | |
 | CH*SHE | Shell Recharge | 29.06.2023 | |
 | CH*SCHARGE | S-Charge | 14.06.2021 |


### PR DESCRIPTION
As a consequence of the [founding of PLUG'N ROLL AG as a subsidiary of Repower](https://www.electrive.net/2023/08/18/repower-macht-plugn-roll-zur-eigenstaendigen-tochter/), we'd like to claim CH*PNR operator ID.